### PR TITLE
"Display mit Ausschnitt simulieren"

### DIFF
--- a/German/main/Settings.apk/res/values-de/strings.xml
+++ b/German/main/Settings.apk/res/values-de/strings.xml
@@ -1899,7 +1899,7 @@ Wenn es so bleibt, muss die App evtl. deinstalliert werden, um die Akkuleistung 
   <string name="display_auto_rotate_stay_in_portrait">Hochformat fixieren</string>
   <string name="display_auto_rotate_title">Bildschirminhalt drehen</string>
   <string name="display_category_title">Bildschirm</string>
-  <string name="display_cutout_emulation">Display mit Ausschnitt simulieren</string>
+  <string name="display_cutout_emulation">Display mit Notch simulieren</string>
   <string name="display_cutout_emulation_keywords">displayausschnitt, notch</string>
   <string name="display_cutout_emulation_none">Nichts</string>
   <string name="display_dashboard_summary">Hintergrund, schlafen, Schriftgröße</string>


### PR DESCRIPTION
Niemand verwendet den Begriff "Ausschnitt" um die Notch zu beschreiben.
Denke jeder weiß was mit einer Notch gemeint ist und wird nicht durch den Begriff "Displayausschnitt" welcher auch etwas anderes bedeuten könnte verwirrt.